### PR TITLE
use bankai@next

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -100,7 +100,7 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai',
+        'bankai@next',
         'standard'
       ]
       var msg = clrInstall(pkgs)


### PR DESCRIPTION
Just published bankai `v9.0.0-1` (oops), and given it's the first version that supports service workers and server rendering I reckon we use it (:

Think this a minor release, given the API of `create-choo-app` doesn't change, and it's meant to be run as a one-off anyway (: