### PR TITLE
check that a git user email is set before attempting to commit

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,6 +266,7 @@ exports.devInstall = function (dir, packages, cb) {
 exports.createGit = function (dir, message, cb) {
   var init = 'git init'
   var add = 'git add -A'
+  var config = 'git config user.email'
   var commit = 'git commit -m "' + message + '"'
 
   var popd = pushd(dir)
@@ -275,10 +276,14 @@ exports.createGit = function (dir, message, cb) {
     exec(add, function (err) {
       if (err) return cb(new Error(add))
 
-      exec(commit, function (err) {
-        if (err) return cb(new Error(commit))
-        popd()
-        cb()
+      exec(config, function (err) {
+        if (err) return cb(new Error(config))
+
+        exec(commit, function (err) {
+          if (err) return cb(new Error(commit))
+          popd()
+          cb()
+        })
       })
     })
   })


### PR DESCRIPTION
Git allows you to configure it to force an email to be set before committing to a repo:

`git config --global user.useconfigonly true` 

which breaks `create-choo-app` when it tries to commit:

https://github.com/choojs/create-choo-app/blob/master/index.js#L278

it's probably a small number of users but it took me a bit to track down what was happening because the error was swallowed - I just saw that that the commit command had failed.

