### PR TITLE
fixes so initial "npm run test" passes

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -92,6 +92,7 @@ function create (dir, argv) {
         'choo-log',
         'choo-devtools',
         'choo-service-worker',
+        'sheetify',
         'tachyons'
       ]
       var msg = clrInstall(pkgs)
@@ -101,6 +102,7 @@ function create (dir, argv) {
     function (done) {
       var pkgs = [
         'bankai@next',
+        'dependency-check',
         'standard'
       ]
       var msg = clrInstall(pkgs)

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ exports.writeIndex = function (dir, cb) {
     app.route('/*', require('./views/404'))
 
     if (!module.parent) app.mount('body')
-    else module.exports = app
+    else module.exports = app\n
   `
 
   write(filename, file, cb)
@@ -138,7 +138,7 @@ exports.writeServiceWorker = function (dir, cb) {
           if (keyList[i] !== VERSION) return self.caches.delete(keyList[i])
         }))
       }))
-    })
+    })\n
   `
 
   write(filename, file, cb)
@@ -189,7 +189,7 @@ exports.writeNotFoundView = function (dir, cb) {
           </a>
         </body>
       \`
-    }
+    }\n
   `
 
   mkdirp(dirname, function (err) {
@@ -217,7 +217,7 @@ exports.writeMainView = function (dir, cb) {
           </h1>
         </body>
       \`
-    }
+    }\n
   `
 
   mkdirp(dirname, function (err) {

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ exports.writePackage = function (dir, cb) {
       "build": "bankai build index.js",
       "inspect": "bankai inspect index.js",
       "start": "bankai start index.js",
-      "test": "standard && test-deps",
+      "test": "standard && npm run test-deps",
       "test-deps": "dependency-check . && dependency-check . --extra --no-dev -i tachyons"
     }
   }


### PR DESCRIPTION
So after a fresh run of `create-choo-app`, running `npm test` will result in errors thrown from standard because there are no newlines at the end of these js files.

Added them in all the js files so standard passes.

Also there was an `npm run` missing in the package.json and then a missing dependency-check and sheetify module in devDependencies that made the initial "npm test" fail. Fixed those as well