### PR TITLE
docs: list installed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@
 [![npm version][2]][3] [![build status][4]][5]
 [![downloads][8]][9] [![js-standard-style][10]][11]
 
-Create a fresh choo application
+Create a fresh choo application. It installs [choo](https://github.com/choojs/choo), along with:
+
+- [bankai](https://github.com/choojs/bankai), an asset bundler and static file server
+- [sheetify](https://github.com/stackcss/sheetify/), a CSS bundler
+- [choo-log](https://github.com/choojs/choo-log) and [choo-devtools](https://github.com/choojs/choo-devtools), to improve the development experience
+- [choo-service-worker](https://github.com/choojs/choo-service-worker), for offline support
+- [tachyons](http://tachyons.io/), a CSS toolkit for crazy people
+- [standard](https://standardjs.com/), a JavaScript linter
+- [dependency-check](https://github.com/maxogden/dependency-check), to verify your dependencies are listed in `package.json`
 
 ## Usage
 ```sh


### PR DESCRIPTION
When I look at boilerplate generator tools, I'm usually curious what opinions they add in. Often I can dig through the `package.json` to find that, but it's less obvious where to find it in this project (`bin.js`), so maybe this will make it easier for folks to see what's going on.

I was typing this up for choo docs, but figured it made more sense on this readme.