### PR TITLE
remove choo-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 Create a fresh choo application. It installs [choo](https://github.com/choojs/choo), along with:
 
-- [bankai](https://github.com/choojs/bankai), an asset bundler and static file server
+- [bankai](https://github.com/choojs/bankai), an asset bundler and static file
+  server
 - [sheetify](https://github.com/stackcss/sheetify/), a CSS bundler
-- [choo-log](https://github.com/choojs/choo-log) and [choo-devtools](https://github.com/choojs/choo-devtools), to improve the development experience
-- [choo-service-worker](https://github.com/choojs/choo-service-worker), for offline support
+- [choo-devtools](https://github.com/choojs/choo-devtools) to improve the
+  development experience
+- [choo-service-worker](https://github.com/choojs/choo-service-worker), for
+  offline support
 - [tachyons](http://tachyons.io/), a minimalist CSS toolkit
 - [standard](https://standardjs.com/), a JavaScript linter
-- [dependency-check](https://github.com/maxogden/dependency-check), to verify your dependencies are listed in `package.json`
+- [dependency-check](https://github.com/maxogden/dependency-check), to verify
+  your dependencies are listed in `package.json`
 
 ## Usage
 ```sh

--- a/bin.js
+++ b/bin.js
@@ -88,8 +88,7 @@ function create (dir, argv) {
       print('\nInstalling packages, this might take a couple of minutes.')
       written.push(path.join(dir, 'node_modules'))
       var pkgs = [
-        'choo@next',
-        'choo-log',
+        'choo',
         'choo-devtools',
         'choo-service-worker',
         'sheetify',
@@ -101,7 +100,7 @@ function create (dir, argv) {
     },
     function (done) {
       var pkgs = [
-        'bankai@next',
+        'bankai',
         'dependency-check',
         'standard'
       ]

--- a/index.js
+++ b/index.js
@@ -89,7 +89,6 @@ exports.writeIndex = function (dir, cb) {
     var app = choo()
     if (process.env.NODE_ENV !== 'production') {
       app.use(require('choo-devtools')())
-      app.use(require('choo-log')())
     } else {
       // Enable once you want service workers support. At the moment you'll
       // need to insert the file names yourself & bump the dep version by hand.


### PR DESCRIPTION
Removes `choo-log` from the install step. Depends on https://github.com/choojs/choo-devtools/pull/14, and related to https://github.com/choojs/discuss/issues/2. Thanks!

Sibling PR – https://github.com/choojs/create-choo-electron/pull/6