### PR TITLE
Add store example

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -128,6 +128,12 @@ function create (dir, argv) {
       lib.writeIndex(dir, done)
     },
     function (done) {
+      var filename = 'store.js'
+      printFile(filename)
+      written.push(path.join(dir, filename))
+      lib.writeStore(dir, done)
+    },
+    function (done) {
       var filename = 'sw.js'
       printFile(filename)
       written.push(path.join(dir, filename))


### PR DESCRIPTION
In order to demonstrate how a choo store can be created and used, I've added a `writeStore` method to `index.js` module to create a small example store and added a button interaction to the main view.

Demo:
![choo demo](https://user-images.githubusercontent.com/3051193/31793643-cb8c1ab6-b4ed-11e7-9a19-6cf5b55474b9.gif)

*TODO:*

- [x] figure out how to escape the interpolation in the main view file writer without escaping it in the written file (See line 230 of `index.js`)