### PR TITLE
Scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,28 @@
 [![npm version][2]][3] [![build status][4]][5]
 [![downloads][8]][9] [![js-standard-style][10]][11]
 
-Create a fresh choo application. It installs [choo](https://github.com/choojs/choo), along with:
-
-- [bankai](https://github.com/choojs/bankai), an asset bundler and static file
-  server
-- [sheetify](https://github.com/stackcss/sheetify/), a CSS bundler
-- [choo-devtools](https://github.com/choojs/choo-devtools) to improve the
-  development experience
-- [choo-service-worker](https://github.com/choojs/choo-service-worker), for
-  offline support
-- [tachyons](http://tachyons.io/), a minimalist CSS toolkit
-- [standard](https://standardjs.com/), a JavaScript linter
-- [dependency-check](https://github.com/maxogden/dependency-check), to verify
-  your dependencies are listed in `package.json`
+Create a fresh choo application. Because starting a new project should take
+minutes, not days.
 
 ## Usage
 ```sh
 $ npx create-choo-app <project-directory>
 ```
+
+## Dependencies
+`create-choo-app` installs the following dependencies:
+
+Name                                                                 | Dependency Type | Description |
+---------------------------------------------------------------------|-----------------|-------------|
+[choo](https://github.com/choojs/choo)                               | Production      | Fast, 4kb framework.
+[choo-service-worker](https://github.com/choojs/choo-service-worker) | Production      | Offline support for Choo.
+[sheetify](https://github.com/stackcss/sheetify/)                    | Production      | Hyper performant CSS-in-JS.
+[tachyons](http://tachyons.io/)                                      | Production      | A minimalist CSS toolkit.
+[bankai](https://github.com/choojs/bankai)                           | Development     | An asset bundler and static file server.
+[choo-devtools](https://github.com/choojs/choo-devtools)             | Development     | Debug Choo applications.
+[choo-scaffold](https://github.com/choojs/choo-scaffold)             | Development     | Generate new application files.
+[dependency-check](https://github.com/maxogden/dependency-check)     | Development     | Verify project dependencies.
+[standard](https://standardjs.com/)                                  | Development     | Statically check JavaScript files for errors.
 
 ## API
 ```txt

--- a/bin.js
+++ b/bin.js
@@ -101,6 +101,7 @@ function create (dir, argv) {
     function (done) {
       var pkgs = [
         'bankai',
+        'choo-scaffold',
         'dependency-check',
         'standard'
       ]

--- a/bin.js
+++ b/bin.js
@@ -129,7 +129,7 @@ function create (dir, argv) {
       lib.writeIndex(dir, done)
     },
     function (done) {
-      var filename = 'store.js'
+      var filename = 'stores/clicks.js'
       printFile(filename)
       written.push(path.join(dir, filename))
       lib.writeStore(dir, done)

--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ exports.writeIcon = function (dir, cb) {
 }
 
 exports.writeStore = function (dir, cb) {
-  var filename = path.join(dir, 'store.js')
+  var filename = path.join(dir, 'stores/clicks.js')
   var file = dedent`
     module.exports = store
 
@@ -277,7 +277,10 @@ exports.writeStore = function (dir, cb) {
     }\n
   `
 
-  write(filename, file, cb)
+  mkdirp(path.dirname(filename), function (err) {
+    if (err) return cb(err)
+    write(filename, file, cb)
+  })
 }
 
 exports.install = function (dir, packages, cb) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ exports.writePackage = function (dir, cb) {
     "private": true,
     "scripts": {
       "build": "bankai build index.js",
+      "create": "choo-scaffold",
       "inspect": "bankai inspect index.js",
       "start": "bankai start index.js",
       "test": "standard && npm run test-deps",
@@ -72,6 +73,7 @@ exports.writeReadme = function (dir, cb) {
     \`$ npm start\`        | Start the development server
     \`$ npm test\`         | Lint, validate deps & run tests
     \`$ npm run build\`    | Compile all files into \`dist/\`
+    \`$ npm run create\`   | Generate a scaffold file
     \`$ npm run inspect\`  | Inspect the bundle's dependencies
   `
 


### PR DESCRIPTION
Added a new command: `npm run create`; can be used to scaffold out new files with a single command. Beats copying over a whole bunch of boilerplate (especially going to be useful with components).

Also cleaned up the readme slightly. Hope this good!

## See Also
- https://github.com/choojs/choo-scaffold/