### PR TITLE
Fix require path for the clicks store

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ exports.writeIndex = function (dir, cb) {
   var file = dedent`
     var css = require('sheetify')
     var choo = require('choo')
-    var store = require('./store')
+    var store = require('./stores/clicks')
 
     css('tachyons')
 


### PR DESCRIPTION
This updates the require path for stores to reflect the new folder layout of `stores/clicks.js`. Before this, bankai wouldn't actually start compiling on a newly generated app until this was updated.