### PR TITLE
service worker update

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,13 +115,8 @@ exports.writeServiceWorker = function (dir, cb) {
   var file = dedent`
     /* global self */
 
-    var VERSION = String(Date.now())
-    var URLS = [
-      '/',
-      '/bundle.css',
-      '/bundle.js',
-      'assets/icon.png'
-    ]
+    var VERSION = require('./package.json').version
+    var URLS = process.env.FILE_LIST
 
     // Respond with cached resources
     self.addEventListener('fetch', function (e) {


### PR DESCRIPTION
ref #43

This address the following

- Use package.json version as sw version
- Use bankai FILE_LIST as the urls to cache