### PR TITLE
pass process.env along to exec call for npm install

### DIFF
--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ exports.install = function (dir, packages, cb) {
   packages = packages.join(' ')
   var cmd = 'npm install --save --loglevel error ' + packages
   var popd = pushd(dir)
-  exec(cmd, function (err) {
+  exec(cmd, {env: process.env}, function (err) {
     if (err) return cb(new Error(cmd))
     popd()
     cb()
@@ -410,7 +410,7 @@ exports.devInstall = function (dir, packages, cb) {
   packages = packages.join(' ')
   var cmd = 'npm install --save-dev --loglevel error ' + packages
   var popd = pushd(dir)
-  exec(cmd, function (err) {
+  exec(cmd, {env: process.env}, function (err) {
     if (err) return cb(new Error(cmd))
     popd()
     cb()


### PR DESCRIPTION
When being behind a proxy, using `create-choo-app` fails because `exec` doesn't preserve environment variables such as `https_proxy` and `http_proxy`.

This enables env variables like `http_proxy` and `https_proxy` to be preserved.


/cc @yoshuawuyts 