### PR TITLE
Accurate eslint service worker declaration

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ exports.writeIndex = function (dir, cb) {
 exports.writeServiceWorker = function (dir, cb) {
   var filename = path.join(dir, 'sw.js')
   var file = dedent`
-    /* global self */
+    /* eslint-env serviceworker */
 
     var VERSION = require('./package.json').version
     var URLS = process.env.FILE_LIST


### PR DESCRIPTION
According to [standard specs](https://github.com/standard/standard#what-about-web-workers), using

```js
/* eslint-env serviceworker */
```

instead of global self is a good choice.