### PR TITLE
fix: correct occured->occurred typo in error message

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -187,7 +187,7 @@ async function create (dir, description, argv) {
 
   series(cmds, function (err) {
     if (err) {
-      print('\nAborting installation. The following error occured:')
+      print('\nAborting installation. The following error occurred:')
       print('  ' + clr(err.message, 'red') + '\n')
       mapLimit(written, 1, cleanFile, function (err) {
         if (err) throw err


### PR DESCRIPTION
Fixes the typo 'occured' -> 'occurred' in the error message printed when installation aborts (bin.js line 190).

1 file, 1 line change. Simple typo fix in error output string.